### PR TITLE
ci: modernize deploy workflow; add PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,50 @@
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+  links:
+    name: Check Internal Links
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Check internal links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            --include-fragments
+            './public/**/*.html'
+          fail: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,90 +1,47 @@
-name: Deploy Blog
+name: Deploy
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    # Step 1 - Checks-out your repository under $GITHUB_WORKSPACE
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-          submodules: true  # Fetch Hugo themes
-          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    # Step 2 - Sets up the latest version of Hugo
-    - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
-      with:
-          hugo-version: 'latest'
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
 
-    # Step 3 - Clean and don't fail
-    - name: Clean public directory
-      run: rm -rf public
+      - name: Build
+        run: hugo --minify
 
-    # Step 4 - Builds the site using the latest version of Hugo
-    # Also specifies the theme we want to use
-    - name: Build
-      run: hugo --theme=hugo-book
+      - name: Create CNAME
+        run: echo 'extra-ransom.net' > public/CNAME
 
-    # Step 5 - Create name file
-    - name: Create cname file
-      run: echo 'extra-ransom.net' > public/CNAME
-
-    # Step 6 - Push our generated site to our gh-pages branch
-    - name: Deploy
-      uses: peaceiris/actions-gh-pages@v3
-      with:
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
 
-    - name: Set AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
 
-    - name: sync to s3 bucket
-      run: |
-        aws s3 sync ./public/ s3://www.extra-ransom.net/ --delete
+      - name: Sync to S3
+        run: aws s3 sync ./public/ s3://www.extra-ransom.net/ --delete
 
-    - name: Invalidate Cloudfront Cache
-      run: |
-          aws cloudfront create-invalidation --distribution-id E2498U24MEPPED --paths "/"
-
-      # - name: Caching Gatsby
-      #   id: gatsby-cache-build
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       public
-      #       .cache
-      #       node_modules
-      #     key: ${{ runner.os }}-gatsby-tommyorndorff-site-build-${{ github.run_id }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-gatsby-tommyorndorff-site-build-
-      # - name: Install dependencies
-      #   run: npm install
-      # - name: install gatsby cli
-      #   run: npm install -g gatsby-cli@4.6.1
-      # - name: Build
-      #   run: gatsby build
-      # - name: verify build
-      #   run: ls -la public
-      # - name: set aws credentials
-      #   uses: aws-actions/configure-aws-credentials@v1
-      #   with:
-      #     aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      #     aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      #     aws-region: us-east-1
-      # - name: sync to s3 bucket
-      #   run: |
-      #     aws s3 sync ./public/ s3://www.extra-ransom.net/ --delete
-      # - name: invalidate cloudfront
-      #   run: |
-      #     aws cloudfront create-invalidation --distribution-id E2498U24MEPPED --paths "/"
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id E2498U24MEPPED \
+            --paths "/*"


### PR DESCRIPTION
Deploy workflow (workflow.yml):
- Bump actions/checkout v2 → v4
- Bump peaceiris/actions-hugo v2 → v3
- Bump peaceiris/actions-gh-pages v3 → v4
- Bump aws-actions/configure-aws-credentials v1 → v4
- Pin hugo-version to 0.163.3 (was 'latest', non-reproducible)
- Remove submodules: true (hugo-book submodule removed, using modules)
- Remove --theme=hugo-book flag (theme loaded via go.mod)
- Add --minify to build
- Fix CloudFront invalidation path "/" → "/*" (was leaving deep pages stale after every deploy)
- Strip dead Gatsby comment block

PR checks (pr-checks.yml, new):
- Triggers on pull_request to main
- build job: verifies hugo --minify succeeds
- links job: builds then runs lychee in offline mode to catch broken internal links and fragment anchors before merge