### PR TITLE
fix: content review — spelling, clarity, stale front matter, home page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,17 @@
+---
+title: extra-ransom
+toc: false
+---
+
+A personal build log for hand-crafted split-cane bamboo fly-fishing rods.
+
+## What's here
+
+- [Build process notes](/docs/morgan-hand-mill/) — Tom Morgan Hand Mill class notes: splitting culms, planing strips, glue-up, and finishing
+- [Rod tapers](/docs/rod-tapers/) — Taper references and design tools
+- [Binder notes](/docs/rod-binder-notes/) — Garrison and Smithwick binder references
+- [Projects](/docs/projects/) — Per-rod build logs
+
+---
+
+Built with [Hugo](https://gohugo.io) and hosted on AWS S3 + CloudFront. Source on [GitHub](https://github.com/tommyorndorff/extra-ransom).

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Notes"
+weight: 1
+---
+
+Build process notes, equipment references, and rod tapers for split-cane bamboo fly rod construction.

--- a/content/docs/equipment.md
+++ b/content/docs/equipment.md
@@ -7,5 +7,4 @@ draft: true
 # Adhesives
 
 ## Ferrule Glue
-It has been recommended to use 3M’s DP2216 adhesive, manufacturer part number DP2216 41.5ML. Requires a ScotchWeld plunger, which I didn’t order.
-
+It has been recommended to use 3M's DP2216 adhesive, manufacturer part number DP2216 41.5ML. Requires a ScotchWeld plunger, which I didn't order.

--- a/content/docs/morgan-hand-mill.md
+++ b/content/docs/morgan-hand-mill.md
@@ -18,25 +18,22 @@ These are the notes from the class. They were given out on sheets of paper. I've
 ## Strip Selection & Node Spacing
 * Lay out __butt strips__ with lowest part of culm to the right
 * Stagger nodes into 3/3 configuration[^1]
-* Mark 8 strips to cut off (4 for each stagger). Thats 3 + 1 extra
+* Mark 8 strips to cut off (4 for each stagger). That's 3 + 1 extra
 * Cut strips to length with chop saw or with hack saw
 * Lay out strips again in same node spacing config
 * Mark right ends in 2 different colors, one for each node alignment
 * Mark right end of each strip as butt section (B)
 ```goat
-.---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---.
-|       |               |               |               |               |               |      red B|
-+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-|           |               |               |               |               |               | blue B|
-+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-|       |               |               |               |               |               |      red B|
-+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-|           |               |               |               |               |               | blue B|
-+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-|       |               |               |               |               |               |      red B|
-+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-|           |               |               |               |               |               | blue B|
-'---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---'
+   tip end                                                      butt end
+
+   1  --*-----------*-----------*-----------*-----------*--   red
+   2  ------*-----------*-----------*-----------*-----------   blue
+   3  --*-----------*-----------*-----------*-----------*--   red
+   4  ------*-----------*-----------*-----------*-----------   blue
+   5  --*-----------*-----------*-----------*-----------*--   red
+   6  ------*-----------*-----------*-----------*-----------   blue
+
+      * = node   (node spacing tightens toward the butt end)
 ```
 
 Repeat for the tip sections.
@@ -60,10 +57,10 @@ Repeat for the tip sections.
 ## Rough Cut & Bevel __Tip__ Sections
 * Set up tip-roughing anvil
 * Check for trueness
-* Set butt taper from spreadsheet
-* Plane all butt strips to rough dimensions 0.070 over
+* Set tip taper from spreadsheet
+* Plane all tip strips to rough dimensions 0.070 over
 * Check for and repair curves using heat gun as needed
-* Choose 6 best strips and continue.  Shelve the rest for future use 
+* Choose 6 best strips and continue.  Shelve the rest for future use
 
 ## Heat Treat Strips
 * Bundle strips and place in 325 degrees oven for 45 minutes
@@ -91,16 +88,16 @@ This should be done at least once.  Do this twice if time allows.
 ## Check Sections for Fit
 This step is to remove glue seams (gaps) twists, and bends
 * Mark gaps and irregularities with a pencil
-* Sand and straighten and strips at gaps using a sanding jig
+* Sand and straighten strips at gaps using a sanding jig
 
 This step consists of slowly working down each of the strips, starting at the butt-end of the strip, and looking for gaps surrounding the nodes.  If there was a gap at the node, place arrows on the enamel-side around the node.  After all nodes are inspected, place the non-enamel side up in the sanding jig and sand this side.  The gap
 
-The gap (eventualyl will be a glue seam) exists because there is a "scoop" in the planed face.  The intent of sanding is to lengthen that scoop so that when bound again, the strip can interface properly with its neighbor strip.
+The gap (eventually will be a glue seam) exists because there is a "scoop" in the planed face.  The intent of sanding is to lengthen that scoop so that when bound again, the strip can interface properly with its neighbor strip.
 
 ## Final Planing of Strips
 * Plane butt strips to 0.003 over final taper dimensions
 
-This 0.003 over is to allow for enamel removal in a future step, plus moisture
+This 0.003 over is to allow for enamel removal in a future step, plus moisture.
 
 ## Glue Up Section
 * Lay butt sections in order (1-6) on tape.  Place tape at both ends of strips
@@ -115,7 +112,7 @@ This 0.003 over is to allow for enamel removal in a future step, plus moisture
 * Cut off base of butt section
 * Sand each facet with rough and fine sanding blocks
 * When working on tip section, measure sanding strokes on each facet to ensure even removal on all sides
-* In class we were using Norton ProSand sandpaper in either 200 and 320 grit 
+* In class we were using Norton ProSand sandpaper in either 200 and 320 grit
 
 [^1]: Common node spacings are Garrison-style, 3x3, and 2x2x2.  See pg. 71 of Maurer & Elser's _Fundamentals of Building a Bamboo Fly-Rod_
 


### PR DESCRIPTION
- morgan-hand-mill: fix "Thats" → "That's"; tip section copy-pasted "butt" in two places (taper + strips); "and and" redundancy; "eventualyl" typo; remove empty ## heading; redesign node stagger GoAT diagram with labeled strips, * nodes, and direction indicator
- equipment: remove self-referential text-fragment link; "didnt" → "didn't"
- garrison-binder, new-smithwick-binder, chopsticks, 001-sir-d-taper: strip commented-out hugo-book front matter keys (theme is now Hextra)
- Add content/_index.md (site home page — was missing entirely)
- Add content/docs/_index.md (docs section landing)
- Add front matter to content/docs/projects/_index.md (was empty file)