### PR TITLE
Turquoise redesign, Rod Builds/Binders restructure, and pre-merge link check

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,32 @@
+name: Link Check
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  link-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.163.3'
+          extended: true
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config .lychee.toml
+            --root-dir ${{ github.workspace }}/public
+            ./public
+          fail: true

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,17 @@
+# Config for the pre-merge link check (.github/workflows/link-check.yml).
+
+exclude = [
+  # Documented as intentionally dead in rod-tapers.md ("expect a 404") -
+  # kept alongside its Wayback Machine archive for historical reference.
+  '^http://www\.uwm\.edu/~stetzer/',
+]
+
+max_retries = 3
+retry_wait_time = 5
+timeout = 20
+
+# 403 is accepted alongside the normal 2xx/3xx range: a few referenced
+# vendor/retail sites (e.g. Lowe's) bot-block plain HTTP clients even
+# though the page is fine in a real browser - without this, those read
+# as false-positive breakage on every run.
+accept = [200, 201, 202, 203, 204, 206, 301, 302, 303, 307, 308, 403]

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,69 @@
+/*
+ * Site palette + type. Hextra's primary color is HSL-driven (see the
+ * theme's styles.css @theme block) - overriding the hue/saturation/
+ * lightness vars here re-themes every primary-* shade the compiled
+ * Tailwind build already generated, without touching the theme.
+ *
+ * Palette: a river-water teal (--primary-*) on a cool off-white/near-
+ * black page background instead of the theme's stock white/#111.
+ */
+
+:root {
+  --primary-hue: 174deg;
+  --primary-saturation: 39%;
+  --primary-lightness: 40%;
+
+  --hx-color-dark: #0d1917;
+
+  --hx-font-sans: "Source Sans 3", ui-sans-serif, system-ui, sans-serif;
+  --hx-font-mono: "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.dark {
+  --primary-hue: 174deg;
+  --primary-saturation: 32%;
+  --primary-lightness: 56%;
+}
+
+body {
+  background-color: #f6faf9;
+}
+
+.content h1,
+.content h2,
+.content h3 {
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+}
+
+/* Homepage hero headline: hand-rolled instead of the hero-headline
+ * shortcode's default gray gradient, because the gradient needs
+ * different stops per color scheme and the shortcode's `style` param
+ * can't reach inside the `dark:` variant. */
+.hero-title {
+  font-family: "Fraunces", ui-serif, Georgia, serif;
+  background-image: linear-gradient(120deg, #142420 15%, #3e8e86 85%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dark .hero-title {
+  background-image: linear-gradient(120deg, #bfe3de 10%, #6bb3ab 90%);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .hero-fade-in {
+    animation: hero-fade-in 0.6s ease-out both;
+  }
+
+  @keyframes hero-fade-in {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 baseURL: 'https://www.extra-ransom.net/'
 locale: en-us
-title: super-chainsaw
+title: extra-ransom, super-chainsaw
 
 module:
   imports:

--- a/config.yaml
+++ b/config.yaml
@@ -17,8 +17,8 @@ markup:
 
 menu:
   main:
-    - name: Projects
-      url: /docs/projects/
+    - name: Rod Builds
+      url: /docs/rod-builds/
       weight: 10
     - name: GitHub
       url: https://github.com/tommyorndorff/extra-ransom

--- a/content/_index.md
+++ b/content/_index.md
@@ -29,15 +29,15 @@ A personal build log — bamboo fly rods, woodworking, coffee roasting, and what
   icon="trending-down"
 >}}
 {{< hextra/feature-card
-  title="Binder notes"
-  subtitle="Garrison and Smithwick binder references, plus the 3D-printed builds here."
-  link="/docs/rod-binder-notes/"
+  title="Rod Binders"
+  subtitle="Garrison and Smithwick binder references, plus the 3D-printed and design-study builds here."
+  link="/docs/rod-binders/"
   icon="refresh"
 >}}
 {{< hextra/feature-card
-  title="Projects"
+  title="Rod Builds"
   subtitle="Per-rod build logs, start to finish."
-  link="/docs/projects/"
+  link="/docs/rod-builds/"
   icon="book-open"
 >}}
 {{< hextra/feature-card

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,17 +1,61 @@
 ---
 title: extra-ransom
-toc: false
+layout: hextra-home
 ---
 
-A personal build log for hand-crafted split-cane bamboo fly-fishing rods.
+<div class="hero-fade-in hx:max-w-2xl">
 
-## What's here
+<h1 class="hero-title not-prose hx:text-4xl hx:font-bold hx:leading-tight hx:tracking-tight hx:md:text-5xl hx:py-2">
+Workshop notes.
+</h1>
 
-- [Build process notes](/docs/morgan-hand-mill/) — Tom Morgan Hand Mill class notes: splitting culms, planing strips, glue-up, and finishing
-- [Rod tapers](/docs/rod-tapers/) — Taper references and design tools
-- [Binder notes](/docs/rod-binder-notes/) — Garrison and Smithwick binder references
-- [Projects](/docs/projects/) — Per-rod build logs
+<p class="not-prose hx:text-lg hx:text-gray-600 hx:dark:text-gray-400 hx:mt-2 hx:mb-10">
+A personal build log — bamboo fly rods, woodworking, coffee roasting, and whatever else ends up on the bench.
+</p>
 
----
+</div>
 
-Built with [Hugo](https://gohugo.io) and hosted on AWS S3 + CloudFront. Source on [GitHub](https://github.com/tommyorndorff/extra-ransom).
+{{< hextra/feature-grid cols="3" >}}
+{{< hextra/feature-card
+  title="Build process"
+  subtitle="Splitting culms, planing strips, glue-up, and finishing — the Tom Morgan Hand Mill class notes."
+  link="/docs/morgan-hand-mill/"
+  icon="scissors"
+>}}
+{{< hextra/feature-card
+  title="Rod tapers"
+  subtitle="Taper tables and design tools for planning a blank before you touch a plane."
+  link="/docs/rod-tapers/"
+  icon="trending-down"
+>}}
+{{< hextra/feature-card
+  title="Binder notes"
+  subtitle="Garrison and Smithwick binder references, plus the 3D-printed builds here."
+  link="/docs/rod-binder-notes/"
+  icon="refresh"
+>}}
+{{< hextra/feature-card
+  title="Projects"
+  subtitle="Per-rod build logs, start to finish."
+  link="/docs/projects/"
+  icon="book-open"
+>}}
+{{< hextra/feature-card
+  title="Woodworking"
+  subtitle="Furniture plans, shop builds, printed tools, and the tools worth knowing about."
+  link="/docs/woodworking/"
+  icon="cube"
+>}}
+{{< hextra/feature-card
+  title="Coffee roasting"
+  subtitle="Roaster setup, remote logging, and profiles from the other thing I tinker with."
+  link="/docs/coffee-roasting/"
+  icon="fire"
+>}}
+{{< /hextra/feature-grid >}}
+
+<hr class="hx:mt-16 hx:mb-6 hx:border-gray-200 hx:dark:border-neutral-800" />
+
+<p class="hx:text-sm hx:text-gray-500 hx:dark:text-gray-400 hx:mb-8">
+Built with <a href="https://gohugo.io">Hugo</a>, hosted on AWS S3 + CloudFront. Source on <a href="https://github.com/tommyorndorff/extra-ransom">GitHub</a>.
+</p>

--- a/content/docs/coffee-roasting/logging-roasts.md
+++ b/content/docs/coffee-roasting/logging-roasts.md
@@ -7,14 +7,13 @@ How to export a roast from Artisan and add it as a page on this site.
 
 ## What to Capture Per Roast
 
-At minimum, record:
+Enter bean and weight data straight into Artisan's own **Roast Properties** dialog (`Roast` menu, or click the roast title above the graph) as you go — it's saved into the `.alog` file automatically, so there's nothing to transcribe later:
 
-- Date and batch number
-- Bean origin, variety, and processing (e.g. Ethiopia Yirgacheffe, washed)
-- Green weight (grams) and roast weight out (for calculating roast loss %)
-- Charge temp, first crack time and temp, drop time and temp
-- Artisan roast curve (exported as image)
-- Notes on the roast and cup result
+- **Roast tab**: `Beans` (origin, variety, processing — e.g. "Ethiopia Yirgacheffe, washed"), `Green Weight`, `Roasted Weight` (Artisan computes weight loss % from these two)
+- **Title**: batch identifier, shown on the graph itself
+- **Notes tab**: roasting notes during the session, cupping notes once it's rested
+
+Charge, turning point, first crack, and drop don't need writing down either — mark each one live with Artisan's phase buttons/hotkeys as it happens, and the exact time and temp land on the graph and in the saved profile on their own.
 
 ---
 
@@ -24,16 +23,17 @@ At minimum, record:
 
 After the roast completes (or during):
 
-1. **File > Save Graph** — saves the roast curve as a `.png`.
-2. Alternatively: **File > Print** and print to PDF, then screenshot the curve.
+1. **File > Save Graph** — saves the roast curve as a `.png` (also offers PDF and social-media-sized exports).
 
 For a clean export, use **View > Full Screen** first so the graph fills the window before saving.
 
-### Roast Data (Artisan JSON)
+### Roast Data (Artisan `.alog`)
 
-1. **File > Save** — saves the full roast as an Artisan `.alog` file (JSON format).
+1. **File > Save As** — saves the full roast as an Artisan `.alog` file (JSON format), including every temperature sample, event marker, and the Roast Properties entered above.
 
-This file contains every temperature sample, event marker, and setting from the roast. Keep it alongside the page as a data archive even if you don't embed it in the site.
+Keep this file alongside the page as a data archive even if you don't embed it in the site — it's the only copy of the raw curve data, and it's what [ArtisanViewer](https://artisan-scope.org/) or a future Artisan version would need to re-open the roast.
+
+**Optional:** Artisan's [Autosave](https://artisan-scope.org/docs/autosave/) feature (`Config > Autosave`) can write both the `.alog` and a rendered image/PDF automatically at the end of every roast, using a filename template built from the roast date and bean name — worth setting up once instead of doing the File > Save Graph / File > Save As dance by hand every time.
 
 ---
 
@@ -48,12 +48,12 @@ static/static/coffee-roasting/
 
 Example:
 ```
-static/static/coffee-roasting/2026-07-04-ethiopia-yirgacheffe/roast-curve.png
+static/static/coffee-roasting/2025-01-15-ethiopia-yirgacheffe/roast-curve.png
 ```
 
 The file will be served at:
 ```
-/static/coffee-roasting/2026-07-04-ethiopia-yirgacheffe/roast-curve.png
+/static/coffee-roasting/2025-01-15-ethiopia-yirgacheffe/roast-curve.png
 ```
 
 ---
@@ -63,15 +63,15 @@ The file will be served at:
 Each roast gets its own Markdown file under `content/docs/coffee-roasting/`.
 
 ```bash
-hugo new docs/coffee-roasting/2026-07-04-ethiopia-yirgacheffe.md
+hugo new docs/coffee-roasting/2025-01-15-ethiopia-yirgacheffe.md
 ```
 
 ### Page Template
 
 ```markdown
 ---
-title: "2026-07-04 Ethiopia Yirgacheffe"
-date: 2026-07-04
+title: "2025-01-15 Ethiopia Yirgacheffe"
+date: 2025-01-15
 weight: 200
 ---
 
@@ -88,7 +88,7 @@ weight: 200
 | First crack | 196°C | 9:30 |
 | Drop | 207°C | 11:00 |
 
-![Roast curve](/static/coffee-roasting/2026-07-04-ethiopia-yirgacheffe/roast-curve.png)
+![Roast curve](/static/coffee-roasting/2025-01-15-ethiopia-yirgacheffe/roast-curve.png)
 
 ## Notes
 
@@ -107,7 +107,7 @@ Tasting notes after resting 5–7 days.
 Use `weight` in front matter to control sidebar order. Lower numbers appear first. A convention that works well:
 
 - Section `_index.md`: `weight: 100`
-- Individual roast pages: use the date as a weight, e.g. `weight: 20260704` for 2026-07-04
+- Individual roast pages: use the date as a weight, e.g. `weight: 20250115` for 2025-01-15
 
 This keeps roasts sorted chronologically from oldest (top) to newest (bottom). Reverse it by assigning descending weights.
 
@@ -119,6 +119,6 @@ Add the new page and static files, then push to `main` — CI deploys automatica
 
 ```bash
 git add content/docs/coffee-roasting/ static/static/coffee-roasting/
-git commit -m "roast: 2026-07-04 Ethiopia Yirgacheffe"
+git commit -m "roast: 2025-01-15 Ethiopia Yirgacheffe"
 git push
 ```

--- a/content/docs/rod-binders/_index.md
+++ b/content/docs/rod-binders/_index.md
@@ -1,0 +1,14 @@
+---
+title: "Rod Binders"
+weight: 40
+---
+
+Binder designs and reference notes — the machines that wind the wraps on, not the rods themselves.
+
+## Pages
+
+- [Garrison Binder](garrison-binder) — the reference article: theory, tuning, and troubleshooting
+- [3D-Printed Garrison Binder](printed-garrison-binder) — a Garrison-style binder built from printed parts
+- ['New' Smithwick Binder](new-smithwick-binder) — my first (wooden) binder build
+- [Rod Binder Notes](rod-binder-notes) — Smithwick binder and a gallery of other designs
+- [Ring-Flyer Orbit Binder](ring-flyer-binder) — design study for an orbiting-spool binder

--- a/content/docs/rod-binders/garrison-binder.md
+++ b/content/docs/rod-binders/garrison-binder.md
@@ -1,6 +1,8 @@
 ---
 title: "Garrison Binder"
 weight: 50
+aliases:
+  - /docs/garrison-binder/
 ---
 I've copied this content from [http://www.canerod.com/rodmakers/tips/binder.html](http://www.canerod.com/rodmakers/tips/binder.html) ([Wayback Machine](https://web.archive.org/web/20151005173756/http://www.canerod.com/rodmakers/tips/binder.html)).  I've reformatted it for reading and placed the images in-line after each paragraph.
 

--- a/content/docs/rod-binders/new-smithwick-binder.md
+++ b/content/docs/rod-binders/new-smithwick-binder.md
@@ -1,6 +1,8 @@
 ---
 title: "'New' Smithwick Binder"
 weight: 50
+aliases:
+  - /docs/new-smithwick-binder/
 ---
 
 # 'New' Smithwick Binder

--- a/content/docs/rod-binders/printed-garrison-binder.md
+++ b/content/docs/rod-binders/printed-garrison-binder.md
@@ -1,9 +1,11 @@
 ---
 title: "3D-Printed Garrison Binder"
 weight: 45
+aliases:
+  - /docs/printed-garrison-binder/
 ---
 
-A Garrison-style rod binder built almost entirely from 3D-printed parts. The architecture follows E. Garrison's original — vertical face board, cradle on the top edge with a belt gap, guide wheels and drive wheel on the face, a weight riding the belt's slack loop, and a disc-drag cord tensioner — as documented in detail on the [Garrison Binder](/docs/garrison-binder/) page. Read that page first; all of its tuning guidance applies directly to this build.
+A Garrison-style rod binder built almost entirely from 3D-printed parts. The architecture follows E. Garrison's original — vertical face board, cradle on the top edge with a belt gap, guide wheels and drive wheel on the face, a weight riding the belt's slack loop, and a disc-drag cord tensioner — as documented in detail on the [Garrison Binder](/docs/rod-binders/garrison-binder/) page. Read that page first; all of its tuning guidance applies directly to this build.
 
 Every wheel runs on two 608 skateboard bearings. All bolt holes, counterbores, captive-nut pockets, and adjustment slots are printed in place — **the only drilling in this project is a handful of holes in the wooden face board**.
 
@@ -141,7 +143,7 @@ The trough axis sits 12 mm in front of the board face — the same plane as the 
 
 ### 4. Drive belt
 
-Make a knotless loop from the mason line (this is the same splice described in the [Garrison Binder](/docs/garrison-binder/) article):
+Make a knotless loop from the mason line (this is the same splice described in the [Garrison Binder](/docs/rod-binders/garrison-binder/) article):
 
 1. Thread one end 50 mm into the eye of a large needle.
 2. Push the needle into the hollow braided core of the other end, run it 40 mm inside, and out.
@@ -165,7 +167,7 @@ Cut two 1" dowels to length: measure **H** = bench top to the bottom of the crad
 
 ## Tuning
 
-All of the [Garrison Binder](/docs/garrison-binder/) tuning advice applies. The short version:
+All of the [Garrison Binder](/docs/rod-binders/garrison-binder/) tuning advice applies. The short version:
 
 - **Weight**: start at ~450 g (1 lb). More is not better — if the rod drags in the cradle or the corners chip, remove weight.
 - **Cord tension**: must be *less* than the belt weight. Test per the article — tie a loop in the cord and hang the weight on it; the weight should pull cord off the spool easily. Too much cord tension twists the rod on the first pass.
@@ -177,6 +179,6 @@ All of the [Garrison Binder](/docs/garrison-binder/) tuning advice applies. The 
 
 ## Related
 
-- [Garrison Binder](/docs/garrison-binder/) — the reference article: theory, tuning, and troubleshooting
-- [Rod Binder Notes](/docs/rod-binder-notes/) — Smithwick binder and a gallery of other designs
-- ['New' Smithwick Binder](/docs/new-smithwick-binder/) — my first (wooden) binder build
+- [Garrison Binder](/docs/rod-binders/garrison-binder/) — the reference article: theory, tuning, and troubleshooting
+- [Rod Binder Notes](/docs/rod-binders/rod-binder-notes/) — Smithwick binder and a gallery of other designs
+- ['New' Smithwick Binder](/docs/rod-binders/new-smithwick-binder/) — my first (wooden) binder build

--- a/content/docs/rod-binders/ring-flyer-binder.md
+++ b/content/docs/rod-binders/ring-flyer-binder.md
@@ -1,9 +1,11 @@
 ---
 title: "Ring-Flyer Orbit Binder (Design Study)"
 weight: 200
+aliases:
+  - /docs/projects/ring-flyer-binder/
 ---
 
-A **hypothetical** rod binder that inverts the Garrison principle: instead of a belt spinning the rod while the cord stands still, **the rod never rotates — the cord spool orbits around it**, the way a cable-serving machine or coil winder lays wire. This page is a design study: the parts are fully engineered and printable, but the machine has not been built yet. Read it alongside the [Garrison Binder](/docs/garrison-binder/) article and the [printed Garrison binder](/docs/printed-garrison-binder/) build, which this design deliberately argues with.
+A **hypothetical** rod binder that inverts the Garrison principle: instead of a belt spinning the rod while the cord stands still, **the rod never rotates — the cord spool orbits around it**, the way a cable-serving machine or coil winder lays wire. This page is a design study: the parts are fully engineered and printable, but the machine has not been built yet. Read it alongside the [Garrison Binder](/docs/rod-binders/garrison-binder/) article and the [printed Garrison binder](/docs/rod-binders/printed-garrison-binder/) build, which this design deliberately argues with.
 
 This concept won a three-way design comparison against a counter-rotating twin-cord binder (fatal flaw: the wrap zone between the rotors can't be hand-steadied, and its twist cancellation silently drifts as the friction drags wear) and a rotisserie chuck-and-leadscrew machine (fatal flaw: driving a wet 2 mm tip section from one end winds radians of torsion into it — the exact defect a binder exists to prevent).
 
@@ -161,6 +163,6 @@ Print PETG throughout; the ring and pinion want 5 perimeters and 40–50% infill
 
 ## Related
 
-- [3D-Printed Garrison Binder](/docs/printed-garrison-binder/) — the conventional build this argues with
-- [Garrison Binder](/docs/garrison-binder/) — the reference article
-- [Rod Binder Notes](/docs/rod-binder-notes/) — more binder designs
+- [3D-Printed Garrison Binder](/docs/rod-binders/printed-garrison-binder/) — the conventional build this argues with
+- [Garrison Binder](/docs/rod-binders/garrison-binder/) — the reference article
+- [Rod Binder Notes](/docs/rod-binders/rod-binder-notes/) — more binder designs

--- a/content/docs/rod-binders/rod-binder-notes.md
+++ b/content/docs/rod-binders/rod-binder-notes.md
@@ -1,6 +1,8 @@
 ---
 title: "Rod Binder Notes"
 weight: 55
+aliases:
+  - /docs/rod-binder-notes/
 ---
 # Notes on Rod Binders 
 Because my brain isn't the lint catch that it used to be, here are some notes for reference.  Preference toward Internet Archive and ensuring they're cataloged in the Wayback Machine.

--- a/content/docs/rod-builds/001-sir-d-taper.md
+++ b/content/docs/rod-builds/001-sir-d-taper.md
@@ -2,6 +2,8 @@
 title: "Rod 001: Sir D 7' 2pc 4wt"
 date: 2022-09-07
 weight: 100
+aliases:
+  - /docs/projects/001-sir-d-taper/
 ---
 
 # Morgan Hand Mill Settings

--- a/content/docs/rod-builds/_index.md
+++ b/content/docs/rod-builds/_index.md
@@ -1,6 +1,8 @@
 ---
-title: "Projects"
+title: "Rod Builds"
 weight: 50
+aliases:
+  - /docs/projects/
 ---
 
 Build logs for individual rods.

--- a/content/docs/rod-builds/chopsticks.md
+++ b/content/docs/rod-builds/chopsticks.md
@@ -1,6 +1,8 @@
 ---
 title: "Miscellaneous"
 weight: 400
+aliases:
+  - /docs/projects/chopsticks/
 ---
 # Chopsticks, Why Not
 I'm going to have a load of extra bamboo strips, so why not use them.

--- a/content/docs/rod-builds/chopsticks.md
+++ b/content/docs/rod-builds/chopsticks.md
@@ -8,6 +8,6 @@ aliases:
 I'm going to have a load of extra bamboo strips, so why not use them.
 
 ## Peak Bamboo
-[Peak Bamboo](https://peakbamboo.com/) has a PDF published about how to make [bamboo chopsticks](https://peakbamboo.com/wp-content/uploads/2017/05/Making-Bamboo-Chopsticks.pdf). 
+[Peak Bamboo](https://peakbamboo.com/) ([Wayback Machine](https://web.archive.org/web/20240229010506/https://peakbamboo.com/)) has a PDF published about how to make [bamboo chopsticks](https://peakbamboo.com/wp-content/uploads/2017/05/Making-Bamboo-Chopsticks.pdf) ([Wayback Machine](https://web.archive.org/web/20210725015744/https://peakbamboo.com/wp-content/uploads/2017/05/Making-Bamboo-Chopsticks.pdf)). 
 
 I'm going to give this a shape, marking out a taper and building it.

--- a/content/docs/rod-builds/printable-rod-tools.md
+++ b/content/docs/rod-builds/printable-rod-tools.md
@@ -1,6 +1,8 @@
 ---
 title: "3D-Printed Rodmaking Tools"
 weight: 300
+aliases:
+  - /docs/projects/printable-rod-tools/
 ---
 
 Small shop tools for the bamboo build process. The blank-making tools tie to steps of the [Morgan Hand Mill workflow](/docs/morgan-hand-mill/); the grip, ferrule, and finishing tools serve the later stages the class notes stop short of. All are FDM-printable in PETG or PLA, generated parametrically, and validated watertight. STLs export in print orientation.
@@ -45,7 +47,7 @@ A 250 mm plate with a 60° V-channel down its length. The strip drops in point-d
 
 **For:** cord payoff during binding — implements the Garrison article's spool fix.
 
-The bulk cord spool rides an M8 axle that drops into open cradle slots in the two uprights. The Ø3.5 socket in the base takes a 1/8" brass rod bent into an overhead loop: cord comes off the spool up through the loop, and the springy rod absorbs tension spikes instead of passing them into the wrap — the exact shock-absorber trick from the [Garrison Binder](/docs/garrison-binder/) article.
+The bulk cord spool rides an M8 axle that drops into open cradle slots in the two uprights. The Ø3.5 socket in the base takes a 1/8" brass rod bent into an overhead loop: cord comes off the spool up through the loop, and the springy rod absorbs tension spikes instead of passing them into the wrap — the exact shock-absorber trick from the [Garrison Binder](/docs/rod-binders/garrison-binder/) article.
 
 [`spool_caddy.stl`](/static/rod-tools-3d/spool_caddy.stl) · print 1 · hardware: M8 × 120 bolt (or M8 rod) + washers, ~300 mm of 1/8" brass rod, 4 wood screws
 
@@ -98,5 +100,5 @@ PETG or PLA, 0.2 mm layers, 3–4 perimeters, 30–40% infill. No supports on an
 ## Related
 
 - [Morgan Hand Mill](/docs/morgan-hand-mill/) — the build process these tools serve
-- [3D-Printed Garrison Binder](/docs/printed-garrison-binder/) — the binder these support
-- [Ring-Flyer Orbit Binder](/docs/projects/ring-flyer-binder/) — design study for an orbiting-spool binder
+- [3D-Printed Garrison Binder](/docs/rod-binders/printed-garrison-binder/) — the binder these support
+- [Ring-Flyer Orbit Binder](/docs/rod-binders/ring-flyer-binder/) — design study for an orbiting-spool binder

--- a/content/docs/woodworking/_index.md
+++ b/content/docs/woodworking/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Woodworking"
+weight: 110
+---
+
+Notes on furniture and shop projects outside the bamboo rod bench — plans, builds, and the tools that support them.
+
+## Pages
+
+- [Furniture Plans](furniture-plans) — plans and references for furniture builds
+- [3D-Printed Shop Tools](printed-tools) — printable jigs and tools for woodworking
+- [Tool Links](tool-links) — tools and suppliers worth knowing about

--- a/content/docs/woodworking/furniture-plans.md
+++ b/content/docs/woodworking/furniture-plans.md
@@ -1,0 +1,6 @@
+---
+title: "Furniture Plans"
+weight: 10
+---
+
+Plans and references for furniture builds. Add plans here as projects come together.

--- a/content/docs/woodworking/furniture-plans.md
+++ b/content/docs/woodworking/furniture-plans.md
@@ -1,6 +1,0 @@
----
-title: "Furniture Plans"
-weight: 10
----
-
-Plans and references for furniture builds. Add plans here as projects come together.

--- a/content/docs/woodworking/furniture-plans/_index.md
+++ b/content/docs/woodworking/furniture-plans/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Furniture Plans"
+weight: 10
+---
+
+Plans and references for furniture builds. Add plans here as projects come together.
+
+## Pages
+
+- [Cherry Hallway Console (Proposed)](cherry-hallway-console) — narrow entry console, mortise-and-tenon cherry, drawbored — designed, not yet built

--- a/content/docs/woodworking/furniture-plans/cherry-hallway-console.md
+++ b/content/docs/woodworking/furniture-plans/cherry-hallway-console.md
@@ -1,0 +1,94 @@
+---
+title: "Cherry Hallway Console (Proposed)"
+weight: 10
+---
+
+A **proposed** build — fully dimensioned and detailed, but not yet cut. A narrow wall console for an entry/hallway: drop keys and mail on top, baskets or shoes on the lower shelf. Solid cherry, hand-tool build (stock ripped and thickness-planed by machine; all joinery cut by hand).
+
+- **Overall size:** 42" W × 14" D × 34" H
+- **Top overhang:** 1" all around the leg frame
+- **Lower shelf:** ~10" off the floor, resting on the lower rails
+- **Joinery:** mortise-and-tenon frame, drawbored; floating solid top
+
+```goat
+     .--------------------------------------------.
+     |            solid top (floats, 42")          |
+     +-+------------------------------------------+-+
+       |                                          |
+       |    apron 3.5" (M&T, drawbored)            |
+     .-+------------------------------------------+-.
+     | |                                          | |
+     | |                                          | |    34" H
+     | |                                          | |
+     | +------------------------------------------+ |
+     | |         lower rail 2.5"                   | |
+     | |         shelf, ~10" off floor              | |
+     '-+------------------------------------------+-'
+       |                                          |
+    ===+==========================================+===
+                          14" D
+```
+
+## Why these proportions
+
+The shallow 14" depth is the point of a hallway piece — it hugs the wall and stays out of the traffic path. 34" tall sits at about waist height, comfortable for setting things down (anywhere 30–34" works; taller reads more console-like). 42" long gives presence without dominating a corridor. Legs are 1½" square — slender but honest for this span; go to 1¾" if you want it chunkier. The lower shelf earns its keep both as storage and as a structural tie that stiffens the whole frame.
+
+## Materials
+
+Species: **solid cherry**, clear finish. Cherry darkens dramatically with light over the first few months (pale pink → deep reddish-brown) — plan around that (see notes).
+
+| Stock | Used for | Rough qty (approx) |
+|---|---|---|
+| **8/4** (2" rough) | Legs only | 5–6 bd ft |
+| **4/4** (1" rough) | Top, aprons, lower rails, shelf | 18–20 bd ft |
+
+Only the legs need stock heavier than 4/4. A finished 1½"-square leg cannot come out of 4/4 — rough 4/4 only nets ~¾" of flat, clean stock after jointing and planing out cup/twist. Buy 8/4 and keep the legs seamless. (6/4 is too close to 1½" finished to survive jointing unless you drop the legs to ~1⅜".)
+
+Lamination alternative: two face-glued pieces of 4/4 make a ~1½" blank, but on a 1½"-square leg the glue line lands on two visible faces and will age to a slightly different shade. On a clear-finished cherry piece, 8/4 is worth it. If you do laminate, orient the seam to a back corner.
+
+The 4/4 estimate leaves margin for grain-matching the top and shelf glue-ups and for working around cherry's gum streaks and sapwood.
+
+## Cut list
+
+Dimensions are thickness × width × length. **Cut to the length in the table** — the tenon lengths are already baked in.
+
+| Part | Qty | Stock | T × W × L (cut to this) | Tenons / notes |
+|---|---|---|---|---|
+| Legs | 4 | 8/4 | 1½" × 1½" × 33¼" | Mortised on two adjacent faces |
+| Long aprons (front/back) | 2 | 4/4 | ¾" × 3½" × 39" | 1" tenon each end, mitered tips |
+| Short aprons (sides) | 2 | 4/4 | ¾" × 3½" × 11" | 1" tenon each end, mitered tips |
+| Long lower rails (front/back) | 2 | 4/4 | ¾" × 2½" × 39" | 1" tenon each end, mitered tips |
+| Short lower rails (sides) | 2 | 4/4 | ¾" × 2½" × 11" | 1" tenon each end, mitered tips |
+| Top | 1 | 4/4 | ¾" × 14" × 42" | No joinery; floats on frame |
+| Lower shelf | 1 | 4/4 | ¾" × 12" × 40" | Notch corners 1½" × 1½"; rests on rails |
+
+### Key reference dimensions
+
+- **Shoulder-to-shoulder** (what actually keeps the frame square):
+  - Long aprons & long rails: **37"**
+  - Short aprons & short rails: **9"**
+- The extra 2" on each part = two 1" tenons living inside the legs. Set your shoulder gauge to 37" / 9" and the tenon length falls out on its own.
+- Mortises: ~5/16" wide × ~1" deep. Two tenons meet inside each leg corner — **miter their tips at 45°** so they don't collide.
+
+## Build sequence
+
+1. Mill 4/4 down to a true ¾" in stages, resting between passes — cherry moves as internal tension releases. Leave leg blanks a hair oversized off the planer and take the last shaving by hand.
+2. Lay out and cut all mortises and tenons. Fit each tenon to its mortise before any glue-up.
+3. Glue up two end units: each = a pair of legs + short apron + short lower rail.
+4. Connect the two ends with the long aprons and long rails.
+5. **Dry-clamp the whole frame** and confirm the 37" and 9" shoulder distances land square before committing.
+6. Drawbore the tenons — pins pull the joints tight without clamping across the 42" span.
+7. Drop the shelf onto the four lower rails.
+8. Attach the top with figure-8 fasteners or wooden buttons so the solid top can float (expand/contract seasonally). **Do not glue the top down.**
+
+## Hand-tool & cherry notes
+
+- **Tear-out:** cherry planes beautifully but tears where grain reverses (near figure or the pith). Keep the smoother sharp and finely set, read grain direction before each pass, and keep a card scraper handy for the top glue-up and any tricky patches.
+- **Color / clamps:** don't leave clamps, tape, or stickers on exposed surfaces during glue-up or curing — cherry tans unevenly and you'll get pale patches that never catch up.
+- **Squeeze-out:** scrape off all glue squeeze-out before finishing. Finish over dried glue blocks the darkening and leaves permanent ghost lines.
+
+## Adjustments to consider
+
+- Stretch to 48" long, or drop height to 30".
+- Add a drawer in the front apron (would change the front apron to a rail + drawer pocket).
+- Bump legs to 1¾" square for a heavier look (still cut from 8/4).

--- a/content/docs/woodworking/printed-tools.md
+++ b/content/docs/woodworking/printed-tools.md
@@ -1,0 +1,6 @@
+---
+title: "3D-Printed Shop Tools"
+weight: 20
+---
+
+Printable jigs and shop tools for woodworking projects — the woodworking counterpart to the [rodmaking tool set](/docs/projects/printable-rod-tools/).

--- a/content/docs/woodworking/printed-tools.md
+++ b/content/docs/woodworking/printed-tools.md
@@ -3,4 +3,4 @@ title: "3D-Printed Shop Tools"
 weight: 20
 ---
 
-Printable jigs and shop tools for woodworking projects — the woodworking counterpart to the [rodmaking tool set](/docs/projects/printable-rod-tools/).
+Printable jigs and shop tools for woodworking projects — the woodworking counterpart to the [rodmaking tool set](/docs/rod-builds/printable-rod-tools/).

--- a/content/docs/woodworking/tool-links.md
+++ b/content/docs/woodworking/tool-links.md
@@ -1,0 +1,6 @@
+---
+title: "Tool Links"
+weight: 30
+---
+
+Tools, suppliers, and references worth keeping track of. Add links here as they come up.

--- a/layouts/_partials/custom/head-end.html
+++ b/layouts/_partials/custom/head-end.html
@@ -1,0 +1,6 @@
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,600..700&family=Source+Sans+3:wght@400;600&family=IBM+Plex+Mono:wght@400;500&display=swap"
+  rel="stylesheet"
+/>


### PR DESCRIPTION
## Summary

**Visual redesign**
- Re-theme the primary color from hextra's default blue to a muted river-teal, in both light and dark mode — CSS variable overrides only (`assets/css/custom.css`), no theme files touched.
- Add Fraunces (display) / Source Sans 3 (body) / IBM Plex Mono (code) via the theme's `custom/head-end.html` override hook; docs headings get the serif treatment sitewide.
- Rework the homepage from a plain title + bullet list into a personal notes-style intro and a card grid linking to every section.
- Goofy site title: navbar + browser tab now read "extra-ransom, super-chainsaw" — both meaningless random-generator project names, together.

**Content structure**
- New **Woodworking** section: furniture plans, 3D-printed shop tools, tool links.
- First real furniture plan: a mortise-and-tenon cherry hallway console (ingested from a Claude-generated plan), marked **(Proposed)** since it isn't built yet, with a GoAT front-elevation diagram.
- Reorganized the old flat "Projects" bucket and scattered top-level binder pages into two clear sections: **Rod Builds** (`content/docs/rod-builds/`, per-rod build logs) and **Rod Binders** (`content/docs/rod-binders/`, binder designs + reference notes). Every moved page keeps an `aliases:` entry pointing at its old URL, and every internal cross-link between these pages was updated to the new paths.
- Added a verified Wayback Machine snapshot for peakbamboo.com (homepage + PDF), matching the site's existing archival convention.

**CI**
- New pre-merge **Link Check** workflow (`.github/workflows/link-check.yml` + `.lychee.toml`) — builds the site and checks every internal and external link on pull requests.

## Test plan
- [x] `hugo --minify` builds cleanly (35 pages, no errors)
- [x] Ran the link checker locally against the full production build: 348 unique links, only one pre-existing external link flagged (DNS failure specific to this sandbox — paired with a verified Wayback fallback regardless)
- [x] Verified all 9 URL aliases resolve and every internal cross-link points at its new path
- [x] Screenshotted the homepage, sidebar, and new pages locally (light mode, desktop + mobile) to confirm layout and copy
- [ ] Reviewer: eyeball dark mode and the actual deployed site once merged — dark-mode contrast was verified by computing it manually, not with a screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)