### PR TITLE
Add FIPS-Mouche 2026 Greater Yellowstone fly-fishing dossier

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,9 @@ menu:
     - name: Coffee Roasting
       url: /docs/coffee-roasting/
       weight: 30
+    - name: Fishing
+      url: /docs/fishing/
+      weight: 35
     - name: GitHub
       url: https://github.com/tommyorndorff/extra-ransom
       weight: 40

--- a/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
+++ b/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
@@ -1,0 +1,115 @@
+---
+title: "2026 FIPS-Mouche Dossier: Greater Yellowstone"
+date: 2026-08-24
+weight: 20260824
+---
+
+Prep notes for a guide I fished with, ahead of the [45th FIPS-Mouche World Fly Fishing Championship](https://fips-mouche.cips-fips.com/world/) — September 13–19, 2026, in the Greater Yellowstone region. Sectors rotate across four confirmed venues, north to south: **Hebgen Lake (MT)**, the **Henry's Fork Mesa Falls–Warm River canyon (ID)**, the **Teton River (ID)**, and the **Greys River (WY)**.
+
+> **Competition format:** FIPS-Mouche rules mean barbless single hooks, a hook-size cap, and no added weight on the leader — often no indicator either. That pushes fly choice toward **tungsten-beaded nymphs (weight in the fly)** and tight-line rigs rather than split shot and bobbers. Confirm the current rulebook on the [FIPS-Mouche site](https://fips-mouche.cips-fips.com/world/); it overrides everything below.
+
+Mid-September is the fall transition: cold mornings, Blue-Winged Olives on grey/drizzly days, terrestrials in the warm middle of the day, and an opening streamer window for pre-spawn browns. Everything sits at 5,000–6,500 ft — strong sun, dehydration, afternoon thunderstorms.
+
+## The adjustment
+
+- **Snake River / Yellowstone fine-spotted cutthroat** — native, eager, forgiving. Love attractors and hoppers. The Greys and Teton are cutthroat water.
+- **Rainbows** — wild and strong, the canyon fish (Henry's Fork, Hebgen). Pull hard.
+- **Brown trout** — fall aggression, streamers all week, especially Hebgen and the Teton.
+- **Brook trout / whitefish** — bonus fish in the tribs and freestone stretches.
+
+Tippet finer than instinct on meadow/flat water (5–7X); heavier for canyon nymphing and streamers.
+
+**Wading boots:** felt soles are legal in Montana, Idaho, and Wyoming, so none of the four confirmed venues ban them outright. But Yellowstone National Park itself [bans felt-soled boots while fishing](https://gearjunkie.com/outdoor/hunt-fish/yellowstone-bans-felt-sole-wading-boots) (invasive species/didymo control), and given how close all four venues sit to the park, rubber soles (studded if needed) are the safer default for the whole trip rather than swapping boots depending on which side of a boundary line you're on.
+
+## Maps
+
+- [Hebgen Lake, Madison Arm — Google Maps](https://www.google.com/maps/search/?api=1&query=Madison+Arm+Hebgen+Lake+Montana)
+- [Henry's Fork, Mesa Falls to Warm River — Google Maps](https://www.google.com/maps/search/?api=1&query=Mesa+Falls+Warm+River+Henry%27s+Fork+Idaho)
+- [Teton River, Tetonia to Newdale — Google Maps](https://www.google.com/maps/search/?api=1&query=Teton+River+Tetonia+Newdale+Idaho)
+- [Greys River, Alpine to Wyoming Peak — Google Maps](https://www.google.com/maps/search/?api=1&query=Greys+River+Road+Alpine+Wyoming)
+- [Henry's Fork Foundation — Angler Access & Maps](https://henrysfork.org/access-sites-maps/) — access-point PDFs with GPS coordinates for the Mesa Falls / Warm River stretch
+- [Idaho Fish & Game Fishing Planner — Teton River](https://idfg.idaho.gov/ifwis/fishingplanner/water/1118383438988) — interactive map, KMZ download
+- [onX Offroad — Greys River Road trail map](https://www.onxmaps.com/offroad/trails/us/wyoming/greys-river-road) — road conditions/difficulty for the Forest Service road that parallels the whole river
+
+## Local knowledge stops
+
+### Kelly Galloup's Slide Inn (Madison River, Cameron MT)
+
+[slideinn.com](https://www.slideinn.com/) — fly shop, guide service, and lodging on 1,100 ft of Madison River frontage. Kelly Galloup bought the Slide Inn in 2000; the shop has one of the best streamer selections in the country and guides the Madison, Jefferson, and Yellowstone rivers. Galloup pioneered modern streamer tactics on western rivers and designed the **Sex Dungeon**, **Zoo Cougar**, **Barely Legal**, and **Peanut Envy** — exactly the pattern family that matters for the pre-spawn brown window on Hebgen and the Teton this trip. [About the Slide Inn](https://www.slideinn.com/about-the-slide-inn/) has the fuller history.
+
+### Blue Ribbon Flies (West Yellowstone, MT)
+
+[blueribbonflies.com](https://www.blueribbonflies.com/) — founded in 1982 by Craig Mathews and John Juracek, a few blocks from Yellowstone's west entrance. Mathews and Juracek developed the **Sparkle Dun** and **Iris Caddis** to solve the exact "gulper" and emerger problems Hebgen's rainbows and browns present on calm mornings, and co-developed the **X-Caddis** — [tying the X-Caddis](https://blog.avidmax.com/2018/09/11/how-to-tie-the-x-caddis-fly-tying-video/) — specifically to fool big, picky rainbows on the Henry's Fork, which makes it a direct fit for venue #2 below. The shop's detailed knowledge covers the Madison, Gallatin, Yellowstone, Firehole, Gibbon, and the regional spring creeks and lakes, and it's also known for a long-running conservation program (catch-and-release advocacy, 1% for the Planet founding member).
+
+## Venue notes and confidence flies
+
+### 1. Hebgen Lake — Madison Arm (top venue, MT)
+
+Fertile reservoir on the Madison near West Yellowstone; rainbow and brown water, not cutthroat. The signature game is **"gulpers"** — on calm mornings, rainbows and browns cruise the surface sipping Callibaetis and Trico spinners. Sight-fish a moving fish, lead it, let it come to the fly; wind kills the game, so it's dawn-to-mid-morning. By mid-September, gulper fishing continues on flat-calm mornings, but fish are also dropping to leeches/chironomids and **browns are staging to run the Madison** — streamer water opens up.
+
+- Callibaetis Sparkle Dun / cripple / spinner (#14–16) — [tying the Sparkle Dun](https://blog.avidmax.com/2019/10/15/how-to-tie-the-sparkle-dun-fly-tying-instructional-video-recipe/)
+- Trico spinner (#18–22)
+- Callibaetis nymph (#14–16), damsel nymph (#10–12)
+- Chironomid / buzzer under an indicator (#14–18) — loch buzzers apply directly here
+- Leeches & Woolly Buggers, black/olive/maroon (#6–10)
+
+### 2. Henry's Fork — Mesa Falls to Warm River canyon (ID)
+
+Not the Railroad Ranch flats (those are upstream) — this is **Cardiac Canyon** below the falls, a steep, lightly-fished stretch of big wild rainbows down to the gentler Warm River confluence. Freestone/pocket water: high-stick or Euro nymphing, attractor dry-dropper, not delicate flat-water presentation. Warm River itself (bottom end) is the easy-access, mellow option. Expect fall BWOs and mahogany duns, terrestrials on sunny days, and October caddis starting to show late in the month.
+
+- Chubby Chernobyl / foam attractor (#8–12) — [tying the Chubby Chernobyl](https://blog.fishwest.com/fly-tying-tutorial-chubby-chernobyl/)
+- X-Caddis (#14–18) — Blue Ribbon Flies' own pattern for this exact water, see above
+- Pat's Rubber Legs (#6–10) and tungsten Perdigon / Frenchie / Pheasant Tail (#12–16) — [tying the Frenchie](https://svenddiesel.com/blogs/tutorial/the-frenchie-jig-nymph-fly-pattern-tutorial), [tying Perdigon nymphs](https://hawker-overend.com/fly-tying-perdigon-nymphs/)
+- Parachute Adams / Purple Haze (#12–16) — [Purple Haze recipe](https://www.jsflyfishing.com/pages/flybrary/parachute-purple-haze)
+- BWO & mahogany duns (#16–18)
+- October Caddis (#8–10, late Sept); streamers (sculpin/bugger) for the big fish
+
+### 3. Teton River — Tetonia canyon down toward Newdale (ID)
+
+Two rivers in one: around Tetonia/Driggs it's a slow, weedy, spring-creek-like meadow — technical, fine tippet, good drift. Dropping northwest toward Newdale/Chester it enters a basalt canyon that fishes more like freestone. Dry-dropper / hopper-dropper covers both. Yellowstone cutthroat are forgiving on the meadow flats (which can still be surprisingly picky); canyon browns like streamers. Terrestrials peak here in September, alongside fall BWO and mahogany.
+
+- Hopper — Morrish / Chubby (#8–12)
+- Foam ant & beetle (#14–16) — deadly droppers on this water
+- Parachute Adams / Purple Haze (#14–16)
+- BWO & mahogany duns (#16–18)
+- Pheasant Tail & rubber legs subsurface; small streamers for browns
+
+### 4. Greys River — Alpine up to Wyoming Peak (WY)
+
+Long freestone canyon river in the Bridger-Teton National Forest, flowing north into the Snake at Alpine. Classic eager-cutthroat-on-attractor-dries water — riffle-run-pool, wade-friendly, accessed via Greys River Road (FS Rd 10138), which parallels the whole river. Snake River fine-spotted cutthroat dominate, with browns/rainbows/brookies mixed in. By September, flows are dropping and clear — good wading, but low clear water makes fish spooky, so add stealth.
+
+- Chubby Chernobyl (#8–12), Royal Wulff / Royal Trude / Stimulator (#10–14) — [Royal Wulff & Stimulator background](https://www.missoulianangler.com/pages/top-6-attractor-fly-patterns)
+- Parachute Adams / Purple Haze (#12–16)
+- Hopper (#8–12) + PT / Prince dropper (#14–16)
+- BWO (#18) on grey afternoons; October Caddis (#8–10) late — [October Caddis pupa recipe](https://www.flytyer.com/october-caddis-pupa/); small bugger
+
+## Streamer box (Slide Inn patterns, all venues)
+
+For the pre-spawn brown window on Hebgen and the Teton:
+
+- [Sex Dungeon](https://flyguysnlies.com/flies/sex-dungeon/) — articulated muddler-head streamer, Galloup's signature big-fish fly
+- [Zoo Cougar](https://www.youtube.com/watch?v=TTaISxC1kAU) — the single-hook half of the Sex Dungeon system, easier to swing on a tighter FIPS-legal leader
+
+## Other notable regional patterns
+
+Flies with real history here that are worth knowing about, even where they're not this trip's top picks.
+
+- **Turck's Tarantula** — [background & recipe](https://www.yellowstoneangler.com/turck-s-tarantula.html) — Jack Dennis–era Jackson Hole attractor, still a solid searching dry on the Greys and Teton canyon water.
+- **Improved Sofa Pillow** and **Madam X** — classic regional salmonfly (Pteronarcys) dries, tied for the big June/early-July stonefly hatch on the Madison and Henry's Fork. **Not a September pattern for this trip** — the hatch will be long over; listed here only because guides will bring them up as "the" local fly.
+- **Bitch Creek Nymph** and **Girdle Bug** — [Bitch Creek tying notes](https://www.johnkreft.com/stonefly-fly-patterns/bitch-creek-nymph/) — the classic stonefly-nymph pair for this whole region, woven chenille bodies with rubber legs. **Do not tie or fish the traditional version as-is**: both are conventionally weighted with lead wire under the body, which is (a) illegal added-leader/fly weight under FIPS-Mouche rules and (b) lead tackle is banned outright in Yellowstone-area park waters regardless of format. If you want the profile, re-tie on a tungsten bead or with tungsten underwire instead of lead — same silhouette, competition- and park-legal.
+
+## Quick confidence box (tie regardless of venue)
+
+| Category | Patterns | Sizes |
+|---|---|---|
+| Euro/comp nymphs | Tungsten Perdigon, Frenchie, jig PT | 12–18 |
+| Big nymph | Pat's Rubber Legs / Girdle Bug | 6–10 |
+| Fall mayfly dries | CDC BWO, Sparkle Dun, Mahogany dun | 16–22 |
+| Trico / Callibaetis (Hebgen) | Spinner, cripple | 14–22 |
+| Terrestrials | Chubby, hopper, foam ant, beetle | 8–16 |
+| Attractors | Royal Wulff, Stimulator, Purple Haze | 10–14 |
+| Streamers | Sex Dungeon, Zoo Cougar, bugger | 4–8 |
+| Stillwater (Hebgen) | Callibaetis nymph, damsel, chironomid, leech | 6–18 |
+| October caddis (late) | Pupa & adult | 8–10 |
+
+**Weather read:** grey/drizzle lights up BWO dry fishing on the rivers but kills the Hebgen gulper window (needs calm). Warm bluebird afternoons favor terrestrials/attractors on the rivers. Any day, the streamer bite for browns is worth a session — best on Hebgen and the Teton.

--- a/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
+++ b/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
@@ -4,7 +4,7 @@ date: 2026-08-24
 weight: 20260824
 ---
 
-Prep notes for a guide I fished with, ahead of the [45th FIPS-Mouche World Fly Fishing Championship](https://fips-mouche.cips-fips.com/world/) — September 13–19, 2026, in the Greater Yellowstone region. Sectors rotate across four confirmed venues, north to south: **Hebgen Lake (MT)**, the **Henry's Fork Mesa Falls–Warm River canyon (ID)**, the **Teton River (ID)**, and the **Greys River (WY)**.
+Prep notes for a guide I fished with, ahead of the [45th FIPS-Mouche World Fly Fishing Championship](https://fips-mouche.cips-fips.com/world/) — September 12–19, 2026 (competition sessions the 14th–18th), hosted out of Idaho Falls in the Greater Yellowstone region. Teams rotate through **five competition sectors** across Idaho, Montana, and Wyoming: **Hebgen Lake (MT)**, the **Henry's Fork of the Snake (ID)**, the **Warm River (ID)**, **Sheridan Lake (WY)**, and the **Greys River (WY)** — two stillwaters and three moving-water beats. This dossier covers those five, plus the **Teton River (ID)**, which we also fished as nearby practice water even though it isn't an official sector.
 
 > **Competition format:** FIPS-Mouche rules mean barbless single hooks, a hook-size cap, and no added weight on the leader — often no indicator either. That pushes fly choice toward **tungsten-beaded nymphs (weight in the fly)** and tight-line rigs rather than split shot and bobbers. Confirm the current rulebook on the [FIPS-Mouche site](https://fips-mouche.cips-fips.com/world/); it overrides everything below.
 
@@ -12,40 +12,41 @@ Mid-September is the fall transition: cold mornings, Blue-Winged Olives on grey/
 
 ## The adjustment
 
-- **Snake River / Yellowstone fine-spotted cutthroat** — native, eager, forgiving. Love attractors and hoppers. The Greys and Teton are cutthroat water.
-- **Rainbows** — wild and strong, the canyon fish (Henry's Fork, Hebgen). Pull hard.
-- **Brown trout** — fall aggression, streamers all week, especially Hebgen and the Teton.
+- **Snake River / Yellowstone fine-spotted cutthroat** — native, eager, forgiving. Love attractors and hoppers. The Greys is cutthroat water.
+- **Rainbows** — wild and strong: the canyon fish (Henry's Fork), and the trophy Kamloops-strain fish on Sheridan Lake. Pull hard.
+- **Brown trout** — fall aggression, streamers all week, especially on Hebgen as fish stage to run the Madison.
 - **Brook trout / whitefish** — bonus fish in the tribs and freestone stretches.
 
 Tippet finer than instinct on meadow/flat water (5–7X); heavier for canyon nymphing and streamers.
 
-**Wading boots:** felt soles are legal in Montana, Idaho, and Wyoming, so none of the four confirmed venues ban them outright. But Yellowstone National Park itself [bans felt-soled boots while fishing](https://gearjunkie.com/outdoor/hunt-fish/yellowstone-bans-felt-sole-wading-boots) (invasive species/didymo control), and given how close all four venues sit to the park, rubber soles (studded if needed) are the safer default for the whole trip rather than swapping boots depending on which side of a boundary line you're on.
+**Wading boots:** felt soles are legal in Montana, Idaho, and Wyoming, so none of the five sectors ban them outright. But Yellowstone National Park itself [bans felt-soled boots while fishing](https://gearjunkie.com/outdoor/hunt-fish/yellowstone-bans-felt-sole-wading-boots) (invasive species/didymo control), and given how close this whole circuit sits to the park — plus the private-water hygiene rules on Sheridan Lake — rubber soles (studded if needed) are the safer default for the trip rather than swapping boots depending on which side of a boundary line you're on.
 
 ## Maps
 
 - [Hebgen Lake, Madison Arm — Google Maps](https://www.google.com/maps/search/?api=1&query=Madison+Arm+Hebgen+Lake+Montana)
 - [Henry's Fork, Mesa Falls to Warm River — Google Maps](https://www.google.com/maps/search/?api=1&query=Mesa+Falls+Warm+River+Henry%27s+Fork+Idaho)
-- [Teton River, Tetonia to Newdale — Google Maps](https://www.google.com/maps/search/?api=1&query=Teton+River+Tetonia+Newdale+Idaho)
 - [Greys River, Alpine to Wyoming Peak — Google Maps](https://www.google.com/maps/search/?api=1&query=Greys+River+Road+Alpine+Wyoming)
+- [Teton River, Tetonia to Newdale — Google Maps](https://www.google.com/maps/search/?api=1&query=Teton+River+Tetonia+Newdale+Idaho) (practice water, see below)
 - [Henry's Fork Foundation — Angler Access & Maps](https://henrysfork.org/access-sites-maps/) — access-point PDFs with GPS coordinates for the Mesa Falls / Warm River stretch
 - [Idaho Fish & Game Fishing Planner — Teton River](https://idfg.idaho.gov/ifwis/fishingplanner/water/1118383438988) — interactive map, KMZ download
 - [onX Offroad — Greys River Road trail map](https://www.onxmaps.com/offroad/trails/us/wyoming/greys-river-road) — road conditions/difficulty for the Forest Service road that parallels the whole river
+- Sheridan Lake is private, restricted-access water — no public map; access is arranged through the event/landowner.
 
 ## Local knowledge stops
 
 ### Kelly Galloup's Slide Inn (Madison River, Cameron MT)
 
-[slideinn.com](https://www.slideinn.com/) — fly shop, guide service, and lodging on 1,100 ft of Madison River frontage. Kelly Galloup bought the Slide Inn in 2000; the shop has one of the best streamer selections in the country and guides the Madison, Jefferson, and Yellowstone rivers. Galloup pioneered modern streamer tactics on western rivers and designed the **Sex Dungeon**, **Zoo Cougar**, **Barely Legal**, and **Peanut Envy** — exactly the pattern family that matters for the pre-spawn brown window on Hebgen and the Teton this trip. [About the Slide Inn](https://www.slideinn.com/about-the-slide-inn/) has the fuller history.
+[slideinn.com](https://www.slideinn.com/) — fly shop, guide service, and lodging on 1,100 ft of Madison River frontage. Kelly Galloup bought the Slide Inn in 2000; the shop has one of the best streamer selections in the country and guides the Madison, Jefferson, and Yellowstone rivers. Galloup pioneered modern streamer tactics on western rivers and designed the **Sex Dungeon**, **Zoo Cougar**, **Barely Legal**, and **Peanut Envy** — exactly the pattern family that matters for the pre-spawn brown window on Hebgen. [About the Slide Inn](https://www.slideinn.com/about-the-slide-inn/) has the fuller history.
 
 ### Blue Ribbon Flies (West Yellowstone, MT)
 
-[blueribbonflies.com](https://www.blueribbonflies.com/) — founded in 1982 by Craig Mathews and John Juracek, a few blocks from Yellowstone's west entrance. Mathews and Juracek developed the **Sparkle Dun** and **Iris Caddis** to solve the exact "gulper" and emerger problems Hebgen's rainbows and browns present on calm mornings, and co-developed the **X-Caddis** — [tying the X-Caddis](https://blog.avidmax.com/2018/09/11/how-to-tie-the-x-caddis-fly-tying-video/) — specifically to fool big, picky rainbows on the Henry's Fork, which makes it a direct fit for venue #2 below. The shop's detailed knowledge covers the Madison, Gallatin, Yellowstone, Firehole, Gibbon, and the regional spring creeks and lakes, and it's also known for a long-running conservation program (catch-and-release advocacy, 1% for the Planet founding member).
+[blueribbonflies.com](https://www.blueribbonflies.com/) — founded in 1982 by Craig Mathews and John Juracek, a few blocks from Yellowstone's west entrance. Mathews and Juracek originated the **Sparkle Dun**, **Iris Caddis**, and **X-Caddis** — [tying the X-Caddis](https://blog.avidmax.com/2018/09/11/how-to-tie-the-x-caddis-fly-tying-video/) — a family of trailing-shuck emergers developed on the Yellowstone-area rivers (especially the Madison) to solve the caddis- and mayfly-emergence refusals you also see on the Henry's Fork and on calm-morning gulpers at Hebgen. The shop's detailed knowledge covers the Madison, Gallatin, Yellowstone, Firehole, Gibbon, and the regional spring creeks and lakes, and it's also known for a long-running conservation program (catch-and-release advocacy, 1% for the Planet founding member).
 
 ## Venue notes and confidence flies
 
-### 1. Hebgen Lake — Madison Arm (top venue, MT)
+### 1. Hebgen Lake — Madison Arm (MT, stillwater sector)
 
-Fertile reservoir on the Madison near West Yellowstone; rainbow and brown water, not cutthroat. The signature game is **"gulpers"** — on calm mornings, rainbows and browns cruise the surface sipping Callibaetis and Trico spinners. Sight-fish a moving fish, lead it, let it come to the fly; wind kills the game, so it's dawn-to-mid-morning. By mid-September, gulper fishing continues on flat-calm mornings, but fish are also dropping to leeches/chironomids and **browns are staging to run the Madison** — streamer water opens up.
+Fertile ~12,500-acre reservoir on the Madison near West Yellowstone; rainbow and brown water, not cutthroat. The signature game is **"gulpers"** — on calm mornings, rainbows and browns cruise the surface sipping Callibaetis and Trico spinners. Sight-fish a moving fish, lead it, let it come to the fly; wind kills the game, so it's dawn-to-mid-morning. By mid-September, gulper fishing continues on flat-calm mornings, but fish are also dropping to leeches/chironomids and **browns are staging to run the Madison** — streamer water opens up.
 
 - Callibaetis Sparkle Dun / cripple / spinner (#14–16) — [tying the Sparkle Dun](https://blog.avidmax.com/2019/10/15/how-to-tie-the-sparkle-dun-fly-tying-instructional-video-recipe/)
 - Trico spinner (#18–22)
@@ -53,28 +54,38 @@ Fertile reservoir on the Madison near West Yellowstone; rainbow and brown water,
 - Chironomid / buzzer under an indicator (#14–18) — loch buzzers apply directly here
 - Leeches & Woolly Buggers, black/olive/maroon (#6–10)
 
-### 2. Henry's Fork — Mesa Falls to Warm River canyon (ID)
+### 2. Henry's Fork of the Snake — Mesa Falls canyon (ID)
 
-Not the Railroad Ranch flats (those are upstream) — this is **Cardiac Canyon** below the falls, a steep, lightly-fished stretch of big wild rainbows down to the gentler Warm River confluence. Freestone/pocket water: high-stick or Euro nymphing, attractor dry-dropper, not delicate flat-water presentation. Warm River itself (bottom end) is the easy-access, mellow option. Expect fall BWOs and mahogany duns, terrestrials on sunny days, and October caddis starting to show late in the month.
+Not the Railroad Ranch flats (those are upstream) — the beat we scouted is **Cardiac Canyon** below the falls, a steep, lightly-fished stretch of big wild rainbows. (The comp's Henry's Fork sector may sit on more accessible water; confirm the exact boundaries once posted.) Freestone/pocket water: high-stick or Euro nymphing, attractor dry-dropper, not delicate flat-water presentation. Expect fall BWOs and mahogany duns, terrestrials on sunny days, and October caddis starting to show late in the month.
 
 - Chubby Chernobyl / foam attractor (#8–12) — [tying the Chubby Chernobyl](https://blog.fishwest.com/fly-tying-tutorial-chubby-chernobyl/)
-- X-Caddis (#14–18) — Blue Ribbon Flies' own pattern for this exact water, see above
+- X-Caddis (#14–18) — Blue Ribbon Flies' caddis emerger, right at home on this water; see above
 - Pat's Rubber Legs (#6–10) and tungsten Perdigon / Frenchie / Pheasant Tail (#12–16) — [tying the Frenchie](https://svenddiesel.com/blogs/tutorial/the-frenchie-jig-nymph-fly-pattern-tutorial), [tying Perdigon nymphs](https://hawker-overend.com/fly-tying-perdigon-nymphs/)
 - Parachute Adams / Purple Haze (#12–16) — [Purple Haze recipe](https://www.jsflyfishing.com/pages/flybrary/parachute-purple-haze)
 - BWO & mahogany duns (#16–18)
 - October Caddis (#8–10, late Sept); streamers (sculpin/bugger) for the big fish
 
-### 3. Teton River — Tetonia canyon down toward Newdale (ID)
+### 3. Warm River (ID, moving-water sector)
 
-Two rivers in one: around Tetonia/Driggs it's a slow, weedy, spring-creek-like meadow — technical, fine tippet, good drift. Dropping northwest toward Newdale/Chester it enters a basalt canyon that fishes more like freestone. Dry-dropper / hopper-dropper covers both. Yellowstone cutthroat are forgiving on the meadow flats (which can still be surprisingly picky); canyon browns like streamers. Terrestrials peak here in September, alongside fall BWO and mahogany.
+A spring-fed tributary to the Henry's Fork — crystal clear, cold, and steady (roughly 10 °C year-round), joining the main river below the Mesa Falls canyon. Easy, wade-friendly access around Warm River Campground; this is the mellow, technical counterpoint to the canyon above. Clear spring-creek water means fine tippet, good drifts, and small flies. Rainbows and browns, with brookies and whitefish mixed in.
 
-- Hopper — Morrish / Chubby (#8–12)
-- Foam ant & beetle (#14–16) — deadly droppers on this water
-- Parachute Adams / Purple Haze (#14–16)
-- BWO & mahogany duns (#16–18)
-- Pheasant Tail & rubber legs subsurface; small streamers for browns
+- Small BWO & mahogany duns (#16–20), midges (#18–22)
+- X-Caddis / CDC caddis emerger (#14–18)
+- Tungsten Perdigon / Frenchie / jig Pheasant Tail (#14–18) — the tight-line comp staples
+- Zebra midge & small Pheasant Tail droppers (#16–20)
+- Foam ant & beetle (#14–16) on sunny afternoons
 
-### 4. Greys River — Alpine up to Wyoming Peak (WY)
+### 4. Sheridan Lake (WY, stillwater sector)
+
+A small (~250-acre), private, restricted-access trophy stillwater — fly-only, catch-and-release, known for big **Kamloops-strain rainbows**. Access is arranged through the event/landowner, not open to the public. This is loch-style still-water: the same skill set as the Hebgen gulper game, but leaning subsurface. Cover water from an anchored/drifting position, hang chironomids at depth, and swim leeches and damsels on a slow retrieve.
+
+- Chironomid / buzzer under an indicator (#10–16) — lake chironomids run large; carry black/red, chromie, olive
+- Leeches & Woolly Buggers, black/olive/maroon (#6–10)
+- Damsel nymph (#10–12)
+- Callibaetis nymph, cripple & spinner (#14–16) for any calm-morning surface window
+- Small attractor/booby-style retrieve flies where legal — confirm against the rulebook
+
+### 5. Greys River — Alpine up to Wyoming Peak (WY)
 
 Long freestone canyon river in the Bridger-Teton National Forest, flowing north into the Snake at Alpine. Classic eager-cutthroat-on-attractor-dries water — riffle-run-pool, wade-friendly, accessed via Greys River Road (FS Rd 10138), which parallels the whole river. Snake River fine-spotted cutthroat dominate, with browns/rainbows/brookies mixed in. By September, flows are dropping and clear — good wading, but low clear water makes fish spooky, so add stealth.
 
@@ -83,18 +94,40 @@ Long freestone canyon river in the Bridger-Teton National Forest, flowing north 
 - Hopper (#8–12) + PT / Prince dropper (#14–16)
 - BWO (#18) on grey afternoons; October Caddis (#8–10) late — [October Caddis pupa recipe](https://www.flytyer.com/october-caddis-pupa/); small bugger
 
-## Streamer box (Slide Inn patterns, all venues)
+### Nearby practice water: Teton River (ID)
 
-For the pre-spawn brown window on Hebgen and the Teton:
+Not a competition sector, but close by and worth a session. Two rivers in one: around Tetonia/Driggs it's a slow, weedy, spring-creek-like meadow — technical, fine tippet, good drift. Dropping northwest toward Newdale/Chester it enters a basalt canyon that fishes more like freestone. Dry-dropper / hopper-dropper covers both. Yellowstone cutthroat are forgiving on the meadow flats (which can still be surprisingly picky); canyon browns like streamers. Terrestrials peak here in September, alongside fall BWO and mahogany.
+
+- Hopper — Morrish / Chubby (#8–12)
+- Foam ant & beetle (#14–16) — deadly droppers on this water
+- Parachute Adams / Purple Haze (#14–16)
+- BWO & mahogany duns (#16–18)
+- Pheasant Tail & rubber legs subsurface; small streamers for browns
+
+## Bonus info: the Firehole soft-hackle swing
+
+Inside Yellowstone NP, the **Firehole River** is the classic home of the **downstream soft-hackle swing** for caddis — a technique worth having in the bag even though the Firehole isn't a competition sector. You fish a soft-hackled caddis emerger (or wet fly) down-and-across through a riffle, letting the current swing it up on a tight line; the rising, hanging fly imitates a pupa swimming to the surface to hatch, and trout hammer it on the swing. It's a centuries-old British-Isles wet-fly method that fishes beautifully here.
+
+This ties straight back to Blue Ribbon Flies: **Craig Mathews** is a well-known advocate of swinging soft-hackles during caddis hatches, and he designed the **Micro Beeley** as a soft-hackle caddis emerger largely for the Firehole. The shop's **Shakey Beeley** soft-hackle is in the same family.
+
+- Micro Beeley / Shakey Beeley soft-hackle (#14–16)
+- Partridge-and-orange or partridge-and-green soft-hackle (#14–16)
+- CDC caddis emerger (#14–18)
+
+> The Firehole is inside Yellowstone National Park: **fly-fishing only, barbless, non-toxic (no lead)**, park permit required, and felt soles banned. It's also thermally warm — fish it early/late in fall and skip it when water temps climb.
+
+## Streamer box (Slide Inn patterns)
+
+For the pre-spawn brown window, best on Hebgen as fish stage to run the Madison:
 
 - [Sex Dungeon](https://flyguysnlies.com/flies/sex-dungeon/) — articulated muddler-head streamer, Galloup's signature big-fish fly
-- [Zoo Cougar](https://www.youtube.com/watch?v=TTaISxC1kAU) — the single-hook half of the Sex Dungeon system, easier to swing on a tighter FIPS-legal leader
+- [Zoo Cougar](https://www.youtube.com/watch?v=TTaISxC1kAU) — a single-hook Galloup streamer, easier to swing on a tighter FIPS-legal leader
 
 ## Other notable regional patterns
 
 Flies with real history here that are worth knowing about, even where they're not this trip's top picks.
 
-- **Turck's Tarantula** — [background & recipe](https://rangeleyflyshop.com/blogs/fly-of-the-month-maine-fly-shop/75811973-turck-s-tarantula) — Guy Turck's Jackson Hole attractor (a buggier take on the Madam X), still a solid searching dry on the Greys and Teton canyon water.
+- **Turck's Tarantula** — [background & recipe](https://rangeleyflyshop.com/blogs/fly-of-the-month-maine-fly-shop/75811973-turck-s-tarantula) — Guy Turck's Jackson Hole attractor (a buggier take on the Madam X), still a solid searching dry on the Greys and the Teton canyon water.
 - **Improved Sofa Pillow** and **Madam X** — classic regional salmonfly (Pteronarcys) dries, tied for the big June/early-July stonefly hatch on the Madison and Henry's Fork. **Not a September pattern for this trip** — the hatch will be long over; listed here only because guides will bring them up as "the" local fly.
 - **Bitch Creek Nymph** and **Girdle Bug** — [Bitch Creek tying notes](https://www.johnkreft.com/stonefly-fly-patterns/bitch-creek-nymph/) — the classic stonefly-nymph pair for this whole region, woven chenille bodies with rubber legs. **Do not tie or fish the traditional version as-is**: both are conventionally weighted with lead wire under the body, which is (a) illegal added-leader/fly weight under FIPS-Mouche rules and (b) lead tackle is banned outright in Yellowstone-area park waters regardless of format. If you want the profile, re-tie on a tungsten bead or with tungsten underwire instead of lead — same silhouette, competition- and park-legal.
 
@@ -105,11 +138,12 @@ Flies with real history here that are worth knowing about, even where they're no
 | Euro/comp nymphs | Tungsten Perdigon, Frenchie, jig PT | 12–18 |
 | Big nymph | Pat's Rubber Legs / Girdle Bug | 6–10 |
 | Fall mayfly dries | CDC BWO, Sparkle Dun, Mahogany dun | 16–22 |
-| Trico / Callibaetis (Hebgen) | Spinner, cripple | 14–22 |
+| Trico / Callibaetis | Spinner, cripple | 14–22 |
+| Caddis emergers | X-Caddis, Micro Beeley soft-hackle | 14–18 |
 | Terrestrials | Chubby, hopper, foam ant, beetle | 8–16 |
 | Attractors | Royal Wulff, Stimulator, Purple Haze | 10–14 |
 | Streamers | Sex Dungeon, Zoo Cougar, bugger | 4–8 |
-| Stillwater (Hebgen) | Callibaetis nymph, damsel, chironomid, leech | 6–18 |
+| Stillwater (Hebgen, Sheridan) | Chironomid, damsel, Callibaetis nymph, leech | 6–18 |
 | October caddis (late) | Pupa & adult | 8–10 |
 
-**Weather read:** grey/drizzle lights up BWO dry fishing on the rivers but kills the Hebgen gulper window (needs calm). Warm bluebird afternoons favor terrestrials/attractors on the rivers. Any day, the streamer bite for browns is worth a session — best on Hebgen and the Teton.
+**Weather read:** grey/drizzle lights up BWO dry fishing on the rivers but kills the calm-morning gulper window on the lakes (Hebgen, Sheridan). Warm bluebird afternoons favor terrestrials/attractors on the rivers. Any day, the streamer bite for browns is worth a session — best on Hebgen.

--- a/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
+++ b/content/docs/fishing/2026-fips-mouche-yellowstone-dossier.md
@@ -94,7 +94,7 @@ For the pre-spawn brown window on Hebgen and the Teton:
 
 Flies with real history here that are worth knowing about, even where they're not this trip's top picks.
 
-- **Turck's Tarantula** — [background & recipe](https://www.yellowstoneangler.com/turck-s-tarantula.html) — Jack Dennis–era Jackson Hole attractor, still a solid searching dry on the Greys and Teton canyon water.
+- **Turck's Tarantula** — [background & recipe](https://rangeleyflyshop.com/blogs/fly-of-the-month-maine-fly-shop/75811973-turck-s-tarantula) — Guy Turck's Jackson Hole attractor (a buggier take on the Madam X), still a solid searching dry on the Greys and Teton canyon water.
 - **Improved Sofa Pillow** and **Madam X** — classic regional salmonfly (Pteronarcys) dries, tied for the big June/early-July stonefly hatch on the Madison and Henry's Fork. **Not a September pattern for this trip** — the hatch will be long over; listed here only because guides will bring them up as "the" local fly.
 - **Bitch Creek Nymph** and **Girdle Bug** — [Bitch Creek tying notes](https://www.johnkreft.com/stonefly-fly-patterns/bitch-creek-nymph/) — the classic stonefly-nymph pair for this whole region, woven chenille bodies with rubber legs. **Do not tie or fish the traditional version as-is**: both are conventionally weighted with lead wire under the body, which is (a) illegal added-leader/fly weight under FIPS-Mouche rules and (b) lead tackle is banned outright in Yellowstone-area park waters regardless of format. If you want the profile, re-tie on a tungsten bead or with tungsten underwire instead of lead — same silhouette, competition- and park-legal.
 

--- a/content/docs/fishing/_index.md
+++ b/content/docs/fishing/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Fishing"
+weight: 120
+---
+
+Notes outside the bamboo rod bench, but adjacent to it — trip prep, venue research, and dossiers put together for guides and friends.
+
+## Pages
+
+- [2026 FIPS-Mouche Dossier: Greater Yellowstone](2026-fips-mouche-yellowstone-dossier) — venue briefing for a guide I fished with, ahead of the 45th World Fly Fishing Championship

--- a/content/docs/fishing/_index.md
+++ b/content/docs/fishing/_index.md
@@ -7,4 +7,4 @@ Notes outside the bamboo rod bench, but adjacent to it — trip prep, venue rese
 
 ## Pages
 
-- [2026 FIPS-Mouche Dossier: Greater Yellowstone](2026-fips-mouche-yellowstone-dossier) — venue briefing for a guide I fished with, ahead of the 45th World Fly Fishing Championship
+- [2026 FIPS-Mouche Dossier: Greater Yellowstone](2026-fips-mouche-yellowstone-dossier) — briefing on the five competition sectors for a guide I fished with, ahead of the 45th World Fly Fishing Championship


### PR DESCRIPTION
## Summary
- Adds a new "Fishing" nav section with a venue dossier for the 45th FIPS-Mouche World Fly Fishing Championship (Sept 2026, Greater Yellowstone) — Hebgen Lake, Henry's Fork, Teton River, and Greys River.
- Includes maps, local fly-shop history (Kelly Galloup's Slide Inn, Blue Ribbon Flies), per-venue confidence flies linked to real tying references, a "notable regional patterns" section flagging off-season/illegal-as-tied patterns (lead-wired Bitch Creek/Girdle Bug), and wading-boot legality notes (felt legal in MT/ID/WY but banned in Yellowstone NP).

## Test plan
- [x] `make build` succeeds with no errors (39 pages)
- [x] New nav item and page render correctly in built output
- [x] `make clean` run after verification, no build artifacts committed