### PR TITLE
fishing: add Colorado trip dossier for Summit County & Carbondale

### DIFF
--- a/content/docs/fishing/2026-colorado-summit-carbondale-dossier.md
+++ b/content/docs/fishing/2026-colorado-summit-carbondale-dossier.md
@@ -1,0 +1,102 @@
+---
+title: "2026 Colorado Dossier: Summit County & Carbondale"
+date: 2026-08-24
+weight: 20260825
+---
+
+Trip prep for Sept 7–25, 2026: **Heaton Bay Campground, Frisco (Sept 7–10 and 21–25)**, with **Carbondale (Sept 10–21)** in between. Heaton Bay sits on **Dillon Reservoir** in Summit County — not Lake Granby/Grand Lake, easy to confuse by name.
+
+> **The headline: 2026 is a historic drought year.** Colorado's water-year snowpack ranked 45th of 46 years on record, and as of mid-August exceptional drought — the worst category — is centered on **Pitkin, Eagle, Summit, Lake, and Park counties**, which covers both legs of this trip. Statewide rivers were running ~59% of normal in August. CPW has active **voluntary noon–midnight closures** on the Colorado, Eagle, and Crystal rivers; the Roaring Fork's closure was lifted Aug 19 after cooler temps and increased Ruedi Reservoir releases. September's seasonal outlook leans above-normal temps and below-normal precip, so don't assume normal fall cooling fixes this fast. **Re-check the [CPW weather and drought closures page](https://cpw.state.co.us/fishing) in the days before departure** — it's the one live variable that changes this plan.
+
+## The adjustment
+
+- Low, clear, technical water almost everywhere except the tailwaters — dawn patrol, long fine leaders, downsized flies.
+- **Tailwaters are the safe bet**: the Blue River (below Dillon Dam) and the Fryingpan River (below Ruedi Reservoir) run cold and clear regardless of the drought, and are largely immune to the closures hitting freestones.
+- **Freestones are the risk**: Crystal, Colorado, and Eagle rivers are under voluntary closure as of late August; treat them as backup water only, and check status before fishing.
+- Pre-spawn brown trout start staging toward the back half of September — streamer window opens on the Fryingpan and Roaring Fork.
+
+## Leg 1 & 3: Frisco / Heaton Bay (Dillon Reservoir, Summit County)
+
+### Dillon Reservoir (stillwater)
+
+~3,200-acre reservoir right at the campground; stocked rainbow, brown, kokanee salmon, and arctic char, plus lake trout. Fair-to-good in August, improving into fall as shallow water cools and fish push out onto points, humps, and rocky structure. Bank and float-tube access is workable near the marina and inlet seams.
+
+- Woolly Bugger, olive/black (#6–10)
+- Leech patterns, black/maroon (#6–10)
+- Pheasant Tail / midge pupa nymphs, drifted at inlet current seams
+- Small streamers stripped along drop-offs as water cools
+
+### Blue River, Silverthorne (tailwater below Dillon Dam)
+
+Your most reliable water on this leg — a true tailwater, cold and clear year-round, unaffected by the drought the way freestones are. Technical: small flies, long leaders, 5x tippet. Trout see everything here.
+
+- Mysis shrimp patterns (#14–16)
+- Zebra Midge, black/red (#20–22)
+- RS2, gray/olive (#20–22)
+- Small BWO nymph
+- Egg patterns if kokanee are running up from the reservoir
+
+### Tenmile Creek (Frisco) / Snake River (Keystone) — backup freestones
+
+Small, roadside/easy-access water for an evening session; expect low, clear, technical conditions given the drought.
+
+- Parachute Adams (#16–18)
+- BWO dry/emerger (#18–20)
+- Hopper-dropper: small foam hopper over a beadhead Pheasant Tail
+
+### Gear for this leg
+
+No need for a dedicated lake rod. A 9' 5–6wt with a spare **intermediate or slow-sink line** covers Dillon Reservoir bank/float-tube work; the same 9' 5wt with a floating line handles the Blue and Tenmile. Only worth adding a heavier trolling/lake-specific outfit if you're fishing from a boat with downriggers — a different game from fly fishing.
+
+## Leg 2: Carbondale (Roaring Fork valley)
+
+### Fryingpan River, Basalt (tailwater below Ruedi Reservoir) — anchor fishery
+
+The one river in the valley largely immune to the drought's worst effects: cold, clear, and fishable all day even in the heat, running roughly 150–200 cfs through late summer. Prioritize this water for the bulk of the 11 days here.
+
+- Mysis shrimp (#14–16)
+- PMD (#16–18) — tailing off by mid-September
+- BWO dry/emerger (#18–20) — picks up on overcast days
+- Midge patterns (#18–22)
+- Pheasant Tail / RS2 nymphs (#16–20)
+
+### Roaring Fork River (Carbondale / Basalt)
+
+Freestone; closure was just lifted (Aug 19) on cooler temps and increased Ruedi releases, but it can return if conditions warm again — check before fishing. Low/clear and technical; dawn patrol matters most below Carbondale.
+
+- Corn-fed Caddis, tan/olive (#14–18)
+- Bionic Hopper (#8–12)
+- Bionic Ant (#14–16)
+- Tungsten split-case / Pheasant Tail nymph (#14–18)
+- Small sculpin streamers at dawn, ramping up as browns stage toward late September
+
+### Crystal River (Carbondale) — backup only, closure active
+
+Extremely low and warm as of late August; voluntary noon–midnight closure in effect. Confirm status before fishing — if open, dawn-only in shaded riffles.
+
+- Small attractor dries, terrestrials
+- Nymph rigs fished in shade/riffle water only
+
+### Colorado River (Glenwood Springs confluence) — lowest priority, closure active
+
+Warmest, most drought-affected water on this trip; treat as a last resort unless flows recover.
+
+- Streamers early/late if fishing
+- Hopper-dropper if flows come back up
+
+### Gear for this leg
+
+Standard 9' 5wt covers everything. Add a 6wt or a beefier leader/tippet setup (3x–4x) if leaning into streamer fishing for staging browns on the Fork in the back half of the stay. No lake-specific gear needed on this leg.
+
+## Quick confidence box
+
+| Category | Patterns | Sizes |
+|---|---|---|
+| Tailwater nymphs | Mysis shrimp, Zebra Midge, RS2 | 16–22 |
+| Fall mayfly | BWO dry/emerger, PMD | 16–20 |
+| Attractor/terrestrial | Corn-fed Caddis, Bionic Hopper, Bionic Ant | 8–18 |
+| Nymphs (general) | Pheasant Tail, tungsten split-case | 14–20 |
+| Streamers | Woolly Bugger, leech, small sculpin | 6–10 |
+| Stillwater (Dillon) | Leech, Woolly Bugger, midge pupa | 6–10 |
+
+**Weather read:** above-normal September temps and below-normal precip mean the drought's low/clear/technical conditions won't ease much on their own — lean on the Blue River and Fryingpan tailwaters as the dependable water, treat the Crystal/Colorado/Eagle freestones as conditional backups, and re-check CPW's closures page right before both legs of the trip.

--- a/content/docs/fishing/_index.md
+++ b/content/docs/fishing/_index.md
@@ -8,3 +8,4 @@ Notes outside the bamboo rod bench, but adjacent to it — trip prep, venue rese
 ## Pages
 
 - [2026 FIPS-Mouche Dossier: Greater Yellowstone](2026-fips-mouche-yellowstone-dossier) — briefing on the five competition sectors for a guide I fished with, ahead of the 45th World Fly Fishing Championship
+- [2026 Colorado Dossier: Summit County & Carbondale](2026-colorado-summit-carbondale-dossier) — Sept 7–25 trip prep for Heaton Bay (Dillon Reservoir) and Carbondale, against a historic drought year


### PR DESCRIPTION
## Summary
- Adds a trip-prep dossier for Sept 7–25, 2026: Heaton Bay (Dillon Reservoir, Summit County) and Carbondale
- Covers Dillon Reservoir, Blue River, Fryingpan, Roaring Fork, Crystal, and Colorado rivers with per-fishery confidence flies and gear notes
- Notes the 2026 historic drought/low-snowpack context and active CPW voluntary closures affecting freestone rivers
- Links the new page from the Fishing section index

## Test plan
- [x] `hugo --theme=hugo-book` builds cleanly with the new page
- [ ] Spot-check rendered page on the deployed site after merge