### PR TITLE
homepage: add CaneDNA callout button

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -13,6 +13,10 @@ Workshop notes.
 A personal build log — bamboo fly rods, woodworking, coffee roasting, and whatever else ends up on the bench.
 </p>
 
+<a href="https://canedna.extra-ransom.net/" target="_blank" rel="noreferrer" class="not-prose hx:inline-flex hx:items-center hx:gap-2 hx:mb-10 hx:px-6 hx:py-3 hx:rounded-full hx:font-bold hx:text-lg hx:text-white hx:bg-primary-600 hx:hover:bg-primary-700 hx:dark:bg-primary-600 hx:dark:hover:bg-primary-700 hx:shadow-xl hx:transition-all hx:ease-out hx:duration-200">
+  CaneDNA is live — try the wasm app →
+</a>
+
 </div>
 
 {{< hextra/feature-grid cols="3" >}}


### PR DESCRIPTION
## Summary
- Adds a solid primary-color CTA pill on the homepage hero linking to https://canedna.extra-ransom.net/, using only utility classes already present in the site's compiled CSS (theme ships its CSS pre-built, not rebuilt per-project).

## Test plan
- [x] `hugo server` locally, confirmed button renders with correct background/text contrast in light mode
- [ ] Spot check dark mode after merge